### PR TITLE
Clean up API

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -37,7 +37,7 @@ func Fuzz(data []byte) int {
 			return 0
 		}
 
-		packet, _, err := Unmarshal(data)
+		packet, err := Unmarshal(data)
 		if err != nil {
 			return 0
 		}

--- a/packet.go
+++ b/packet.go
@@ -11,13 +11,13 @@ type Packet interface {
 }
 
 // Unmarshal is a factory a polymorphic RTCP packet, and its header,
-func Unmarshal(rawPacket []byte) (Packet, Header, error) {
+func Unmarshal(rawPacket []byte) (Packet, error) {
 	var h Header
 	var p Packet
 
 	err := h.Unmarshal(rawPacket)
 	if err != nil {
-		return nil, h, err
+		return nil, err
 	}
 
 	switch h.Type {
@@ -58,5 +58,5 @@ func Unmarshal(rawPacket []byte) (Packet, Header, error) {
 	}
 
 	err = p.Unmarshal(rawPacket)
-	return p, h, err
+	return p, err
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -80,7 +80,7 @@ func TestUnmarshal(t *testing.T) {
 		t.Fatalf("Read rr: %v", err)
 	}
 	var parsed Packet
-	if parsed, _, err = Unmarshal(packet); err != nil {
+	if parsed, err = Unmarshal(packet); err != nil {
 		t.Errorf("Unmarshal parsed: %v", err)
 	}
 	assert.IsType(t, parsed, (*ReceiverReport)(nil), "Unmarshalled to incorrect type")
@@ -108,7 +108,7 @@ func TestUnmarshal(t *testing.T) {
 		t.Fatalf("Read sdes: %v", err)
 	}
 
-	if parsed, _, err = Unmarshal(packet); err != nil {
+	if parsed, err = Unmarshal(packet); err != nil {
 		t.Errorf("Unmarshal parsed: %v", err)
 	}
 	assert.IsType(t, parsed, (*SourceDescription)(nil), "Unmarshalled to incorrect type")
@@ -137,7 +137,7 @@ func TestUnmarshal(t *testing.T) {
 		t.Fatalf("Read bye: %v", err)
 	}
 
-	if parsed, _, err = Unmarshal(packet); err != nil {
+	if parsed, err = Unmarshal(packet); err != nil {
 		t.Errorf("Unmarshal parsed: %v", err)
 	}
 
@@ -156,7 +156,7 @@ func TestUnmarshal(t *testing.T) {
 		t.Fatalf("Read pli: %v", err)
 	}
 
-	if parsed, _, err = Unmarshal(packet); err != nil {
+	if parsed, err = Unmarshal(packet); err != nil {
 		t.Errorf("Unmarshal parsed: %v", err)
 	}
 
@@ -176,7 +176,7 @@ func TestUnmarshal(t *testing.T) {
 		t.Fatalf("Read rrr: %v", err)
 	}
 
-	if parsed, _, err = Unmarshal(packet); err != nil {
+	if parsed, err = Unmarshal(packet); err != nil {
 		t.Errorf("Unmarshal parsed: %v", err)
 	}
 


### PR DESCRIPTION
* Rename Reader -> Decoder
* Return a parsed packet from the decoder
* Return only a parsed packet (no header) from Unmarshal

Am I missing anything? I want to make the API more consistent and easy to use for the v2 release.