### PR TITLE
Revert "Clean up API"

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -37,7 +37,7 @@ func Fuzz(data []byte) int {
 			return 0
 		}
 
-		packet, err := Unmarshal(data)
+		packet, _, err := Unmarshal(data)
 		if err != nil {
 			return 0
 		}

--- a/packet.go
+++ b/packet.go
@@ -11,13 +11,13 @@ type Packet interface {
 }
 
 // Unmarshal is a factory a polymorphic RTCP packet, and its header,
-func Unmarshal(rawPacket []byte) (Packet, error) {
+func Unmarshal(rawPacket []byte) (Packet, Header, error) {
 	var h Header
 	var p Packet
 
 	err := h.Unmarshal(rawPacket)
 	if err != nil {
-		return nil, err
+		return nil, h, err
 	}
 
 	switch h.Type {
@@ -58,5 +58,5 @@ func Unmarshal(rawPacket []byte) (Packet, error) {
 	}
 
 	err = p.Unmarshal(rawPacket)
-	return p, err
+	return p, h, err
 }

--- a/reader.go
+++ b/reader.go
@@ -2,30 +2,29 @@ package rtcp
 
 import "io"
 
-// A Decoder reads packets from an RTCP combined packet.
-type Decoder struct {
+// A Reader reads packets from an RTCP combined packet.
+type Reader struct {
 	r io.Reader
 }
 
-// NewDecoder creates a new Decoder reading from r.
-func NewDecoder(r io.Reader) *Decoder {
-	return &Decoder{r}
+// NewReader creates a new Reader reading from r.
+func NewReader(r io.Reader) *Reader {
+	return &Reader{r}
 }
 
-// DecodePacket reads one packet from r.
+// ReadPacket reads one packet from r.
 //
 // It returns the parsed packet Header and a byte slice containing the encoded
 // packet data (including the header). How the packet data is parsed depends on
 // the Type field contained in the Header.
-func (r *Decoder) DecodePacket() (Packet, error) {
+func (r *Reader) ReadPacket() (header Header, data []byte, err error) {
 	// First grab the header
-	var header Header
 	headerBuf := make([]byte, headerLength)
 	if _, err := io.ReadFull(r.r, headerBuf); err != nil {
-		return nil, err
+		return header, data, err
 	}
 	if err := header.Unmarshal(headerBuf); err != nil {
-		return nil, err
+		return header, data, err
 	}
 
 	packetLen := (header.Length + 1) * 4
@@ -33,9 +32,10 @@ func (r *Decoder) DecodePacket() (Packet, error) {
 	// Then grab the rest
 	bodyBuf := make([]byte, packetLen-headerLength)
 	if _, err := io.ReadFull(r.r, bodyBuf); err != nil {
-		return nil, err
+		return header, data, err
 	}
-	data := append(headerBuf, bodyBuf...)
 
-	return Unmarshal(data)
+	data = append(headerBuf, bodyBuf...)
+
+	return header, data, nil
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -72,14 +72,18 @@ var realPacket = []byte{
 }
 
 func TestUnmarshal(t *testing.T) {
-	d := NewDecoder(bytes.NewReader(realPacket))
+	r := NewReader(bytes.NewReader(realPacket))
 
 	// ReceiverReport
-	packet, err := d.DecodePacket()
+	_, packet, err := r.ReadPacket()
 	if err != nil {
 		t.Fatalf("Read rr: %v", err)
 	}
-	assert.IsType(t, packet, (*ReceiverReport)(nil), "Unmarshalled to incorrect type")
+	var parsed Packet
+	if parsed, err = Unmarshal(packet); err != nil {
+		t.Errorf("Unmarshal parsed: %v", err)
+	}
+	assert.IsType(t, parsed, (*ReceiverReport)(nil), "Unmarshalled to incorrect type")
 
 	wantRR := &ReceiverReport{
 		SSRC: 0x902f9e2e,
@@ -94,16 +98,20 @@ func TestUnmarshal(t *testing.T) {
 		}},
 		ProfileExtensions: []byte{},
 	}
-	if got, want := wantRR, packet; !reflect.DeepEqual(got, want) {
+	if got, want := wantRR, parsed; !reflect.DeepEqual(got, want) {
 		t.Errorf("Unmarshal rr: got %#v, want %#v", got, want)
 	}
 
 	// SourceDescription
-	packet, err = d.DecodePacket()
+	_, packet, err = r.ReadPacket()
 	if err != nil {
 		t.Fatalf("Read sdes: %v", err)
 	}
-	assert.IsType(t, packet, (*SourceDescription)(nil), "Unmarshalled to incorrect type")
+
+	if parsed, err = Unmarshal(packet); err != nil {
+		t.Errorf("Unmarshal parsed: %v", err)
+	}
+	assert.IsType(t, parsed, (*SourceDescription)(nil), "Unmarshalled to incorrect type")
 
 	wantSdes := &SourceDescription{
 		Chunks: []SourceDescriptionChunk{
@@ -119,52 +127,66 @@ func TestUnmarshal(t *testing.T) {
 		},
 	}
 
-	if got, want := packet, wantSdes; !reflect.DeepEqual(got, want) {
+	if got, want := parsed, wantSdes; !reflect.DeepEqual(got, want) {
 		t.Errorf("Unmarshal sdes: got %#v, want %#v", got, want)
 	}
 
 	// Goodbye
-	packet, err = d.DecodePacket()
+	_, packet, err = r.ReadPacket()
 	if err != nil {
 		t.Fatalf("Read bye: %v", err)
 	}
-	assert.IsType(t, packet, (*Goodbye)(nil), "Unmarshalled to incorrect type")
+
+	if parsed, err = Unmarshal(packet); err != nil {
+		t.Errorf("Unmarshal parsed: %v", err)
+	}
+
+	assert.IsType(t, parsed, (*Goodbye)(nil), "Unmarshalled to incorrect type")
 
 	wantBye := &Goodbye{
 		Sources: []uint32{0x902f9e2e},
 	}
-	if got, want := packet, wantBye; !reflect.DeepEqual(got, want) {
+	if got, want := parsed, wantBye; !reflect.DeepEqual(got, want) {
 		t.Errorf("Unmarshal bye: got %#v, want %#v", got, want)
 	}
 
 	// PictureLossIndication
-	packet, err = d.DecodePacket()
+	_, packet, err = r.ReadPacket()
 	if err != nil {
 		t.Fatalf("Read pli: %v", err)
 	}
 
-	assert.IsType(t, packet, (*PictureLossIndication)(nil), "Unmarshalled to incorrect type")
+	if parsed, err = Unmarshal(packet); err != nil {
+		t.Errorf("Unmarshal parsed: %v", err)
+	}
+
+	assert.IsType(t, parsed, (*PictureLossIndication)(nil), "Unmarshalled to incorrect type")
 
 	wantPli := &PictureLossIndication{
 		SenderSSRC: 0x902f9e2e,
 		MediaSSRC:  0x902f9e2e,
 	}
-	if got, want := packet, wantPli; !reflect.DeepEqual(got, want) {
+	if got, want := parsed, wantPli; !reflect.DeepEqual(got, want) {
 		t.Errorf("Unmarshal pli: got %#v, want %#v", got, want)
 	}
 
 	// RapidResynchronizationRequest
-	packet, err = d.DecodePacket()
+	_, packet, err = r.ReadPacket()
 	if err != nil {
 		t.Fatalf("Read rrr: %v", err)
 	}
-	assert.IsType(t, packet, (*RapidResynchronizationRequest)(nil), "Unmarshalled to incorrect type")
+
+	if parsed, err = Unmarshal(packet); err != nil {
+		t.Errorf("Unmarshal parsed: %v", err)
+	}
+
+	assert.IsType(t, parsed, (*RapidResynchronizationRequest)(nil), "Unmarshalled to incorrect type")
 
 	wantRrr := &RapidResynchronizationRequest{
 		SenderSSRC: 0x902f9e2e,
 		MediaSSRC:  0x902f9e2e,
 	}
-	if got, want := packet, wantRrr; !reflect.DeepEqual(got, want) {
+	if got, want := parsed, wantRrr; !reflect.DeepEqual(got, want) {
 		t.Errorf("Unmarshal rrr: got %#v, want %#v", got, want)
 	}
 }
@@ -174,8 +196,8 @@ func TestReadEOF(t *testing.T) {
 		0x81, 0xc9, // missing type & len
 	}
 
-	d := NewDecoder(bytes.NewReader(shortHeader))
-	_, err := d.DecodePacket()
+	r := NewReader(bytes.NewReader(shortHeader))
+	_, _, err := r.ReadPacket()
 	if got, want := err, io.ErrUnexpectedEOF; got != want {
 		t.Fatalf("read short header: got err = %v, want %v", got, want)
 	}

--- a/reader_test.go
+++ b/reader_test.go
@@ -80,7 +80,7 @@ func TestUnmarshal(t *testing.T) {
 		t.Fatalf("Read rr: %v", err)
 	}
 	var parsed Packet
-	if parsed, err = Unmarshal(packet); err != nil {
+	if parsed, _, err = Unmarshal(packet); err != nil {
 		t.Errorf("Unmarshal parsed: %v", err)
 	}
 	assert.IsType(t, parsed, (*ReceiverReport)(nil), "Unmarshalled to incorrect type")
@@ -108,7 +108,7 @@ func TestUnmarshal(t *testing.T) {
 		t.Fatalf("Read sdes: %v", err)
 	}
 
-	if parsed, err = Unmarshal(packet); err != nil {
+	if parsed, _, err = Unmarshal(packet); err != nil {
 		t.Errorf("Unmarshal parsed: %v", err)
 	}
 	assert.IsType(t, parsed, (*SourceDescription)(nil), "Unmarshalled to incorrect type")
@@ -137,7 +137,7 @@ func TestUnmarshal(t *testing.T) {
 		t.Fatalf("Read bye: %v", err)
 	}
 
-	if parsed, err = Unmarshal(packet); err != nil {
+	if parsed, _, err = Unmarshal(packet); err != nil {
 		t.Errorf("Unmarshal parsed: %v", err)
 	}
 
@@ -156,7 +156,7 @@ func TestUnmarshal(t *testing.T) {
 		t.Fatalf("Read pli: %v", err)
 	}
 
-	if parsed, err = Unmarshal(packet); err != nil {
+	if parsed, _, err = Unmarshal(packet); err != nil {
 		t.Errorf("Unmarshal parsed: %v", err)
 	}
 
@@ -176,7 +176,7 @@ func TestUnmarshal(t *testing.T) {
 		t.Fatalf("Read rrr: %v", err)
 	}
 
-	if parsed, err = Unmarshal(packet); err != nil {
+	if parsed, _, err = Unmarshal(packet); err != nil {
 		t.Errorf("Unmarshal parsed: %v", err)
 	}
 


### PR DESCRIPTION
Reverts pions/rtcp#5

Looks like there might be a missing file:

../../../../vendor/github.com/pions/srtp/session_srtcp.go:105:20: undefined: rtcp.NewReader
../../../../vendor/github.com/pions/srtp/session_srtcp.go:116:18: assignment mismatch: 3 variables but 2 values