### PR TITLE
Add REMB packet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Check out the **[contributing wiki](https://github.com/pions/webrtc/wiki/Contrib
 * [Woodrow Douglass](https://github.com/wdouglass) *RTCP, RTP improvements, G.722 support, Bugfixes*
 * [Sean DuBois](https://github.com/Sean-Der) - *Linter fixes*
 * [adwpc](https://github.com/adwpc) - *Fix PictureLossIndication Unmarshal error*
+* [Luke Curley](https://github.com/kixelated)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/pions/rtcp
+
+go 1.12
+
+require github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/header.go
+++ b/header.go
@@ -21,10 +21,11 @@ const (
 
 // Transport and Payload specific feedback messages overload the count field to act as a message type. those are listed here
 const (
-	FormatSLI uint8 = 2
-	FormatPLI uint8 = 1
-	FormatTLN uint8 = 1
-	FormatRRR uint8 = 5
+	FormatSLI  uint8 = 2
+	FormatPLI  uint8 = 1
+	FormatTLN  uint8 = 1
+	FormatRRR  uint8 = 5
+	FormatREMB uint8 = 15
 )
 
 func (p PacketType) String() string {

--- a/packet.go
+++ b/packet.go
@@ -49,6 +49,8 @@ func Unmarshal(rawPacket []byte) (Packet, error) {
 			p = new(PictureLossIndication)
 		case FormatSLI:
 			p = new(SliceLossIndication)
+		case FormatREMB:
+			p = new(ReceiverEstimatedMaximumBitrate)
 		default:
 			p = new(RawPacket)
 		}

--- a/receiver_estimated_maximum_bitrate.go
+++ b/receiver_estimated_maximum_bitrate.go
@@ -1,0 +1,283 @@
+package rtcp
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/bits"
+)
+
+// ReceiverEstimatedMaximumBitrate contains the receiver's estimated maximum bitrate.
+// see: https://tools.ietf.org/html/draft-alvestrand-rmcat-remb-03
+type ReceiverEstimatedMaximumBitrate struct {
+	// SSRC of sender
+	SenderSSRC uint32
+
+	// Estimated maximum bitrate
+	Bitrate uint64
+
+	// SSRC entries which this packet applies to
+	SSRCs []uint32
+}
+
+// Marshal serializes the packet and returns a byte slice.
+func (p ReceiverEstimatedMaximumBitrate) Marshal() (buf []byte, err error) {
+	// Allocate a buffer of the exact output size.
+	buf = make([]byte, p.MarshalSize())
+
+	// Write to our buffer.
+	n, err := p.MarshalTo(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	// This will always be true but just to be safe.
+	if n != len(buf) {
+		return nil, errors.New("wrong marshal size")
+	}
+
+	return buf, nil
+}
+
+// MarshalSize returns the size of the packet when marshaled.
+// This can be used in conjunction with `MarshalTo` to avoid allocations.
+func (p ReceiverEstimatedMaximumBitrate) MarshalSize() (n int) {
+	return 20 + 4*len(p.SSRCs)
+}
+
+// MarshalTo serializes the packet to the given byte slice.
+func (p ReceiverEstimatedMaximumBitrate) MarshalTo(buf []byte) (n int, err error) {
+	/*
+	    0                   1                   2                   3
+	    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |V=2|P| FMT=15  |   PT=206      |             length            |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |                  SSRC of packet sender                        |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |                  SSRC of media source                         |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |  Unique identifier 'R' 'E' 'M' 'B'                            |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |  Num SSRC     | BR Exp    |  BR Mantissa                      |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |   SSRC feedback                                               |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |  ...                                                          |
+	*/
+
+	size := p.MarshalSize()
+	if len(buf) < size {
+		return 0, errors.New("short buffer")
+	}
+
+	buf[0] = 143 // v=2, p=0, fmt=15
+	buf[1] = 206
+
+	// Length of this packet in 32-bit words minus one.
+	length := uint16((p.MarshalSize() / 4) - 1)
+	binary.BigEndian.PutUint16(buf[2:4], length)
+
+	binary.BigEndian.PutUint32(buf[4:8], p.SenderSSRC)
+	binary.BigEndian.PutUint32(buf[8:12], 0) // always zero
+
+	// ALL HAIL REMB
+	buf[12] = 'R'
+	buf[13] = 'E'
+	buf[14] = 'M'
+	buf[15] = 'B'
+
+	// Write the length of the ssrcs to follow at the end
+	buf[16] = byte(len(p.SSRCs))
+
+	// We can only encode 18 bits of information in the mantissa.
+	// The exponent lets us shift to the left up to 64 places (6-bits).
+	// We actually need a uint82 to encode the largest possible number,
+	// but uint64 should be good enough for 2.3 exabytes per second.
+
+	// So we need to truncate the bitrate and use the exponent for the shift.
+	// bitrate = mantissa * (1 << exp)
+
+	// Calculate the total shift based on the leading number of zeroes.
+	// This will be negative if there is no shift required.
+	shift := uint(64 - bits.LeadingZeros64(p.Bitrate))
+
+	var mantissa uint
+	var exp uint
+
+	if shift <= 18 {
+		// Fit everything in the mantissa because we can.
+		mantissa = uint(p.Bitrate)
+		exp = 0
+	} else {
+		// We can only use 18 bits of precision, so truncate.
+		mantissa = uint(p.Bitrate >> (shift - 18))
+		exp = shift - 18
+	}
+
+	// We can't quite use the binary package because
+	// a) it's a uint24 and b) the exponent is only 6-bits
+	// Just trust me; this is big-endian encoding.
+	buf[17] = byte((exp << 2) | (mantissa >> 16))
+	buf[18] = byte(mantissa >> 8)
+	buf[19] = byte(mantissa)
+
+	// Write the SSRCs at the very end.
+	n = 20
+	for _, ssrc := range p.SSRCs {
+		binary.BigEndian.PutUint32(buf[n:n+4], ssrc)
+		n += 4
+	}
+
+	return n, nil
+}
+
+// Unmarshal reads a REMB packet from the given byte slice.
+func (p *ReceiverEstimatedMaximumBitrate) Unmarshal(buf []byte) (err error) {
+	/*
+	    0                   1                   2                   3
+	    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |V=2|P| FMT=15  |   PT=206      |             length            |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |                  SSRC of packet sender                        |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |                  SSRC of media source                         |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |  Unique identifier 'R' 'E' 'M' 'B'                            |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |  Num SSRC     | BR Exp    |  BR Mantissa                      |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |   SSRC feedback                                               |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |  ...                                                          |
+	*/
+
+	// 20 bytes is the size of the packet with no SSRCs
+	if len(buf) < 20 {
+		return errors.New("buffer too short")
+	}
+
+	// version  must be 2
+	version := buf[0] >> 6
+	if version != 2 {
+		return errors.New("version must be 2")
+	}
+
+	// padding must be unset
+	padding := (buf[0] >> 5) & 1
+	if padding != 0 {
+		return errors.New("padding must be 0")
+	}
+
+	// fmt must be 15
+	fmt := buf[0] & 31
+	if fmt != 15 {
+		return errors.New("wrong feedback message type")
+	}
+
+	// Must be payload specific feedback
+	if buf[1] != 206 {
+		return errors.New("wrong payload type")
+	}
+
+	// length is the number of 32-bit words, minus 1
+	length := binary.BigEndian.Uint16(buf[2:4])
+	size := int((length + 1) * 4)
+
+	// There's not way this could be legit
+	if size < 20 {
+		return errors.New("header length is too small")
+	}
+
+	// Make sure the buffer is large enough.
+	if len(buf) < size {
+		return errors.New("buffer too short")
+	}
+
+	// The sender SSRC is 32-bits
+	p.SenderSSRC = binary.BigEndian.Uint32(buf[4:8])
+
+	// The destination SSRC must be 0
+	media := binary.BigEndian.Uint32(buf[8:12])
+	if media != 0 {
+		return errors.New("media SSRC must be 0")
+	}
+
+	// REMB rules all around me
+	if !bytes.Equal(buf[12:16], []byte{'R', 'E', 'M', 'B'}) {
+		return errors.New("missing REMB identifier")
+	}
+
+	// The next byte is the number of SSRC entries at the end.
+	num := int(buf[16])
+
+	// Now we know the expected size, make sure they match.
+	if size != 20+4*num {
+		return errors.New("SSRC num and length do not match")
+	}
+
+	// Get the 6-bit exponent value.
+	exp := buf[17] >> 2
+
+	// The remaining 2-bits plus the next 16-bits are the mantissa.
+	mantissa := uint64(buf[17]&3)<<16 | uint64(buf[18])<<8 | uint64(buf[19])
+
+	// bitrate = mantissa * 2^exp
+
+	if exp > 46 {
+		// NOTE: We intentionally truncate values so they fit in a uint64.
+		// Otherwise we would need a uint82.
+		// This is 2.3 exabytes per second, which should be good enough.
+		p.Bitrate = ^uint64(0)
+	} else {
+		p.Bitrate = mantissa << exp
+	}
+
+	// Clear any existing SSRCs
+	p.SSRCs = nil
+
+	// Loop over and parse the SSRC entires at the end.
+	// We already verified that size == num * 4
+	for n := 20; n < size; n += 4 {
+		ssrc := binary.BigEndian.Uint32(buf[n : n+4])
+		p.SSRCs = append(p.SSRCs, ssrc)
+	}
+
+	return nil
+}
+
+// Header returns the Header associated with this packet.
+func (p *ReceiverEstimatedMaximumBitrate) Header() Header {
+	return Header{
+		Count:  FormatREMB,
+		Type:   TypePayloadSpecificFeedback,
+		Length: uint16((p.MarshalSize() / 4) - 1),
+	}
+}
+
+// Keep a table of powers to units for fast conversion.
+var bitUnits = []string{"b", "Kb", "Mb", "Gb", "Tb", "Pb", "Eb"}
+
+// String prints the REMB packet in a human-readable format.
+func (p *ReceiverEstimatedMaximumBitrate) String() string {
+	// Do some unit conversions because b/s is far too difficult to read.
+	bitrate := float64(p.Bitrate)
+	powers := 0
+
+	// Keep dividing the bitrate until it's under 1000
+	for bitrate >= 1000.0 && powers < len(bitUnits) {
+		bitrate /= 1000.0
+		powers++
+	}
+
+	unit := bitUnits[powers]
+
+	return fmt.Sprintf("ReceiverEstimatedMaximumBitrate %x %.2f %s/s", p.SenderSSRC, bitrate, unit)
+}
+
+// DestinationSSRC returns an array of SSRC values that this packet refers to.
+func (p *ReceiverEstimatedMaximumBitrate) DestinationSSRC() []uint32 {
+	return p.SSRCs
+}

--- a/receiver_estimated_maximum_bitrate_test.go
+++ b/receiver_estimated_maximum_bitrate_test.go
@@ -1,0 +1,131 @@
+package rtcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReceiverEstimatedMaximumBitrateMarshal(t *testing.T) {
+	assert := assert.New(t)
+
+	input := ReceiverEstimatedMaximumBitrate{
+		SenderSSRC: 1,
+		Bitrate:    8927168,
+		SSRCs:      []uint32{1215622422},
+	}
+
+	expected := []byte{143, 206, 0, 5, 0, 0, 0, 1, 0, 0, 0, 0, 82, 69, 77, 66, 1, 26, 32, 223, 72, 116, 237, 22}
+
+	output, err := input.Marshal()
+	assert.NoError(err)
+	assert.Equal(expected, output)
+}
+
+func TestReceiverEstimatedMaximumBitrateUnmarshal(t *testing.T) {
+	assert := assert.New(t)
+
+	// Real data sent by Chrome while watching a 6Mb/s stream
+	input := []byte{143, 206, 0, 5, 0, 0, 0, 1, 0, 0, 0, 0, 82, 69, 77, 66, 1, 26, 32, 223, 72, 116, 237, 22}
+
+	// mantissa = []byte{26 & 3, 32, 223} = []byte{2, 32, 223} = 139487
+	// exp = 26 >> 2 = 6
+	// bitrate = 139487 * 2^6 = 139487 * 64 = 8927168 = 8.9 Mb/s
+	expected := ReceiverEstimatedMaximumBitrate{
+		SenderSSRC: 1,
+		Bitrate:    8927168,
+		SSRCs:      []uint32{1215622422},
+	}
+
+	packet := ReceiverEstimatedMaximumBitrate{}
+	err := packet.Unmarshal(input)
+	assert.NoError(err)
+	assert.Equal(expected, packet)
+}
+
+func TestReceiverEstimatedMaximumBitrateTruncate(t *testing.T) {
+	assert := assert.New(t)
+
+	input := []byte{143, 206, 0, 5, 0, 0, 0, 1, 0, 0, 0, 0, 82, 69, 77, 66, 1, 26, 32, 223, 72, 116, 237, 22}
+
+	// Make sure that we're truncating the bitrate correctly.
+	// For the above example, we have:
+
+	// mantissa = 139487
+	// exp = 6
+	// bitrate = 8927168
+
+	packet := ReceiverEstimatedMaximumBitrate{}
+	err := packet.Unmarshal(input)
+	assert.NoError(err)
+	assert.Equal(uint64(8927168), packet.Bitrate)
+
+	// Just verify marshal produces the same input.
+	output, err := packet.Marshal()
+	assert.NoError(err)
+	assert.Equal(input, output)
+
+	// If we subtract the bitrate by 1, we'll round down a lower mantissa
+	packet.Bitrate--
+
+	// bitrate = 8927167
+	// mantissa = 139486
+	// exp = 6
+
+	output, err = packet.Marshal()
+	assert.NoError(err)
+	assert.NotEqual(input, output)
+
+	// Which if we actually unmarshal again, we'll find that it's actually decreased by 63 (which is exp)
+	// mantissa = 139486
+	// exp = 6
+	// bitrate = 8927104
+
+	err = packet.Unmarshal(output)
+	assert.NoError(err)
+	assert.Equal(uint64(8927104), packet.Bitrate)
+}
+
+func TestReceiverEstimatedMaximumBitrateOverflow(t *testing.T) {
+	assert := assert.New(t)
+
+	// Marshal a packet with the maximum possible bitrate.
+	packet := ReceiverEstimatedMaximumBitrate{
+		Bitrate: 0xFFFFFFFFFFFFFFFF,
+	}
+
+	// bitrate = 0xFFFFFFFFFFFFFFFF
+	// mantissa = 262143 = 0x3FFFF
+	// exp = 46
+
+	expected := []byte{143, 206, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 82, 69, 77, 66, 0, 187, 255, 255}
+
+	output, err := packet.Marshal()
+	assert.NoError(err)
+	assert.Equal(expected, output)
+
+	// mantissa = 262143
+	// exp = 46
+	// bitrate = 0xFFFFC00000000000
+
+	// We actually can't represent the full uint64.
+	// This is because the lower 46 bits are all 0s.
+
+	err = packet.Unmarshal(output)
+	assert.NoError(err)
+	assert.Equal(uint64(0xFFFFC00000000000), packet.Bitrate)
+
+	// Make sure we marshal to the same result again.
+	output, err = packet.Marshal()
+	assert.NoError(err)
+	assert.Equal(expected, output)
+
+	// Finally, try unmarshalling one number higher than we can handle
+	// It's debatable if the bitrate should have all lower 48 bits set.
+	// I think it's better because uint64 overflow is easier to notice/debug.
+	// And it's not like this class can actually ensure Marshal/Unmarshal are mirrored.
+	input := []byte{143, 206, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 82, 69, 77, 66, 0, 188, 0, 0}
+	err = packet.Unmarshal(input)
+	assert.NoError(err)
+	assert.Equal(uint64(0xFFFFFFFFFFFFFFFF), packet.Bitrate)
+}

--- a/reception_report.go
+++ b/reception_report.go
@@ -34,7 +34,7 @@ type ReceptionReport struct {
 	Delay uint32
 }
 
-var (
+const (
 	receptionReportLength = 24
 	fractionLostOffset    = 4
 	totalLostOffset       = 5

--- a/sender_report.go
+++ b/sender_report.go
@@ -38,7 +38,7 @@ type SenderReport struct {
 	ProfileExtensions []byte
 }
 
-var (
+const (
 	srHeaderLength      = 24
 	srSSRCOffset        = 0
 	srNTPOffset         = srSSRCOffset + ssrcLength


### PR DESCRIPTION
Chrome sends this packet by default; even without being properly opted in with `a=rtcp-fb:<payload type> goog-remb`.